### PR TITLE
Fixes package installation failure on 32-bit Windows 7

### DIFF
--- a/tools/chocolateyHelpers.ps1
+++ b/tools/chocolateyHelpers.ps1
@@ -21,7 +21,7 @@ function Get-ChocolateyPackageParameters {
 
 function Get-RabbitMQPath {
   $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
-  if (Test-Path "HKLM:\SOFTWARE\Wow6432Node\") {
+  if (Test-Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ") {
     $regPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
   }
   


### PR DESCRIPTION
When I tried to install latest choco package on Windows 7 x86 I've got an error:
```
ERROR: This command cannot be run due to the error: The system cannot find the file specified.
  at <ScriptBlock>, C:\ProgramData\chocolatey\lib\rabbitmq\tools\chocolateyInstall.ps1: line 15
  at <ScriptBlock>, C:\ProgramData\chocolatey\helpers\chocolateyScriptRunner.ps1: line 48
  at <ScriptBlock>, <No file>: line 1
```

Function `Get-RabbitMQPath` from [chocolateyHelpers.ps1](https://github.com/rabbitmq/chocolatey-package/blob/master/tools/chocolateyHelpers.ps1#L22) checks for `"HKLM:\SOFTWARE\Wow6432Node\"` and if that registry key exists, tries to build RabbitMQ path from `"HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"`.

I have freshly installed Windows 7 x86:
![windows-7](https://user-images.githubusercontent.com/2307197/29244120-0e061dc0-7fb9-11e7-8483-a2293e031dbb.png)

And my registry contains empty `"HKLM:\SOFTWARE\Wow6432Node\"` registry key:
![registry](https://user-images.githubusercontent.com/2307197/29244131-5c4fb450-7fb9-11e7-98a6-4994a63dfc36.png)

In this PR I fixed `$regPath` definition in `Get-RabbitMQPath`, now it checks full `"HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"` key for existence.