### PR TITLE
Changed the required erlang version to 20.3 from 22

### DIFF
--- a/rabbitmq.nuspec
+++ b/rabbitmq.nuspec
@@ -28,7 +28,7 @@ Pull requests are welcome.
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/rabbitmq/chocolatey-package/master/rabbitmq-logo.png</iconUrl>
     <dependencies>
-      <dependency id="erlang" version="[19.3,22)" />
+      <dependency id="erlang" version="[19.3,20.3)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
_Opening a PR because I can't open an issue on the fork._


We recently used this package as part of our release pipeline and ran into the same issue listed in the top comment at the package listing:



> Looks like this package is broken due to Erlang v21 not being RabbitMQ supported.
If you run 'choco install erlang --version 20.3' prior to the RabbitMQ one things go better.

source -https://chocolatey.org/packages/rabbitmq

I received runtime errors during installation when Erlang 22 was specified.  Installing Erlang 20.3 via choco install and then installing Rabbit mq the same way did the trick.

