### PR TITLE
URL Cleanup

### DIFF
--- a/rabbitmq.nuspec
+++ b/rabbitmq.nuspec
@@ -18,13 +18,13 @@ Pull requests are welcome.
  * `/NOMANAGEMENT` - this setting will override the default enabling of the RabbitMQ management console'
  * `/RABBITMQBASE` - specify an optional RABBITMQ_BASE. Note the parameter has no underscore, but the environment variable does. ex:/RABBITMQBASE:C:\ProgramData\RabbitMQ. The default is %AppData\RabbitMQ'
     </description>
-    <projectUrl>http://www.rabbitmq.com/</projectUrl>
+    <projectUrl>https://www.rabbitmq.com/</projectUrl>
     <projectSourceUrl>https://github.com/rabbitmq/rabbitmq-server</projectSourceUrl>
     <packageSourceUrl>https://github.com/rabbitmq/chocolatey-package</packageSourceUrl>
     <releaseNotes>https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.13</releaseNotes>
     <tags>message queueing messaging rabbitmq amqp mqtt stomp admin</tags>
     <copyright>Pivotal Software, Inc.</copyright>
-    <licenseUrl>http://www.rabbitmq.com/mpl.html</licenseUrl>
+    <licenseUrl>https://www.rabbitmq.com/mpl.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/rabbitmq/chocolatey-package/master/rabbitmq-logo.png</iconUrl>
     <dependencies>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd (404) with 1 occurrences could not be migrated:  
   ([https](https://schemas.microsoft.com/packaging/2010/07/nuspec.xsd) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* http://www.rabbitmq.com/mpl.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/mpl.html ([https](https://www.rabbitmq.com/mpl.html) result 200).