### PR TITLE
set HOMEDRIVE env to C: to fix service install issue

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -8,6 +8,7 @@ if ($arguments['RABBITMQBASE']) {
   ${Env:RABBITMQ_BASE} = $arguments['RABBITMQBASE']
 }
 
+$env:HOMEDRIVE=C:
 Install-ChocolateyPackage 'rabbitmq' 'EXE' '/S' 'https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.10.10/rabbitmq-server-3.10.10.exe'
 
 $rabbitPath = Get-RabbitMQPath


### PR DESCRIPTION
Our orghanization sets the HOMEDRIVE to something other than C: and it's a windows share, this seems to mess up the erlang cookie install and breaks choco.

“Failed to create cookie file (drive:)/erlang”