### PR TITLE
Allow all Erlang 25.x versions

### DIFF
--- a/rabbitmq.nuspec
+++ b/rabbitmq.nuspec
@@ -30,7 +30,7 @@ If you are looking for community help with RabbitMQ, see https://www.rabbitmq.co
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/rabbitmq/chocolatey-package/master/rabbitmq-logo.png</iconUrl>
     <dependencies>
-      <dependency id="erlang" version="[25.0,25.2]" />
+      <dependency id="erlang" version="[25.0,26.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This means we won't have to keep bumping it