### PR TITLE
Update how RabbitMQ install dir is found

### DIFF
--- a/tools/chocolateyHelpers.ps1
+++ b/tools/chocolateyHelpers.ps1
@@ -26,8 +26,8 @@ function Get-RabbitMQPath {
   }
 
   if (Test-Path $regPath) {
-    $path = Split-Path -Parent (Get-ItemProperty $regPath "UninstallString").UninstallString
+    $path = (Get-ItemProperty -Name Install_Dir -Path 'HKLM:\SOFTWARE\WOW6432Node\VMware, Inc.\RabbitMQ Server').Install_Dir
     $version = (Get-ItemProperty $regPath "DisplayVersion").DisplayVersion
-    return "$path\rabbitmq_server-$version"
+    return Join-Path -Path $path -ChildPath "rabbitmq_server-$version"
   }
 }


### PR DESCRIPTION
In https://github.com/rabbitmq/rabbitmq-packaging/pull/46, quotes were added around the `UninstallString` value. This would result in an invalid path being created for the RMQ install dir. Rather than strip the double quotes, use the...

```
HKLM:\SOFTWARE\WOW6432Node\VMware, Inc.\RabbitMQ Server
```

...registry key's `Install_Dir` property.