### PR TITLE
Pass `GIST_ID` secret to update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       github_api_key: ${{ secrets.API_KEY }}
       github_user_repo: rabbitmq/chocolatey-package
+      gist_id: ${{ secrets.GIST_ID }}
       api_key: ${{ secrets.CHOCOLATEY_API_KEY }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
The AU Gist plugin updates an existing gist when `gist_id` is set, or creates a new one when it is empty. The `gist_id` environment variable was missing from the workflow, so the plugin was creating a new gist on every daily run instead of updating the existing one. This resulted in 20+ duplicate gists accumulating in the `lukebakken` account.

This change passes the `GIST_ID` repository secret as `gist_id` in the workflow environment. The secret has been set to the ID of the most recent existing gist (`e62c53c31b3a971cefe413a751f4f446`).
